### PR TITLE
local_manifests.xml: Switch to @subhajeetmuhuri's vendor tree

### DIFF
--- a/local_manifests.xml
+++ b/local_manifests.xml
@@ -11,7 +11,7 @@
  <project path="kernel/xiaomi/surya" name="sounddrill31/kernel_xiaomi_surya" remote="gh" revision="PixelOS-14" />
  
  <!--Vendor -->
- <project path="vendor/xiaomi/surya" name="xiaomi-surya/android_vendor_xiaomi_surya" remote="gh" revision="lineage-21" />
+ <project path="vendor/xiaomi/surya" name="subhajeetmuhuri/proprietary_vendor_xiaomi_surya" remote="gh" revision="lineage-21" />
  
  <!--Extras -->
  <!--<project path="packages/resources/devicesettings" name="LineageOS/android_packages_resources_devicesettings" remote="gh" revision="cm-14.1" /> -->


### PR DESCRIPTION
build/make/core/base_rules.mk:292: error: vendor/xiaomi/surya: MODULE.TARGET.SHARED_LIBRARIES.libvendor.goodix.hardware.biometrics.fingerprint@2.1 already defined by device/xiaomi/surya/biometrics.

No need to use prebuilt goodix anymore, since they are now using source built library  https://github.com/subhajeetmuhuri/android_device_xiaomi_surya/commit/8b046c9d22c4cb0983c5f9fa223a80166b9531c3