### PR TITLE
local_manifests.xml: Switch to LineageOS hardware/xiaomi

### DIFF
--- a/local_manifests.xml
+++ b/local_manifests.xml
@@ -15,5 +15,5 @@
  
  <!--Extras -->
  <!--<project path="packages/resources/devicesettings" name="LineageOS/android_packages_resources_devicesettings" remote="gh" revision="cm-14.1" /> -->
-<project path="hardware/xiaomi" name="PixelOS-AOSP/hardware_xiaomi" remote="gh" revision="fourteen" />
+<project path="hardware/xiaomi" name="LineageOS/android_hardware_xiaomi" remote="gh" revision="lineage-21" />
 </manifest>


### PR DESCRIPTION
FAILED: 
build/make/core/main.mk:1376: warning:  device/xiaomi/surya/aosp_surya.mk includes non-existent modules in PRODUCT_PACKAGES Offending entries:
android.hardware.power-service.xiaomi-libperfmgr
com.fingerprints.extension@1.0.vendor
libMegviiFacepp-0.5.2
build/make/core/main.mk:1376: error: Build failed.